### PR TITLE
Update cmake to use latest version from Kitware repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y build-essential git cmake \
+RUN apt-get update && apt-get install -y build-essential git \
     libpcre3-dev libcurl4-openssl-dev libcurl4 luarocks lua5.3 lua5.3-dev \
-    haproxy
+    haproxy apt-transport-https ca-certificates
+    
+    
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && apt purge --auto-remove cmake && apt-get update -y && apt-get install -y cmake
 
 COPY install-c-server-sdk.sh .
 RUN ./install-c-server-sdk.sh


### PR DESCRIPTION
Use cmake version from Kitware bionic repositories. 